### PR TITLE
Add kv.Clear method support

### DIFF
--- a/resources/.phpstorm.meta.php
+++ b/resources/.phpstorm.meta.php
@@ -13,6 +13,7 @@ namespace PHPSTORM_META {
         'kv.MExpire',
         'kv.TTL',
         'kv.Delete',
+        'kv.Clear',
     );
 
     expectedArguments(\Spiral\Goridge\RPC\RPCInterface::call(), 0,

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -475,7 +475,7 @@ class Cache implements StorageInterface
     public function clear(): bool
     {
         try {
-            $this->call('kv.Clears', $this->request([]));
+            $this->call('kv.Clear', $this->request([]));
         } catch (KeyValueException $e) {
             if (\str_contains($e->getMessage(), 'can\'t find method kv.Clear')) {
                 throw new KeyValueException(self::ERROR_CLEAR_NOT_AVAILABLE, (int)$e->getCode(), $e);

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -48,6 +48,14 @@ class Cache implements StorageInterface
         'Storage "%s" does not support kv.TTL RPC method execution. Please ' .
         'use another driver for the storage if you require this functionality';
 
+
+    /**
+     * @var string
+     */
+    private const ERROR_CLEAR_NOT_AVAILABLE =
+        'RoadRunner does not support kv.Clear RPC method. Please ' .
+        'make sure you are using RoadRunner v2.3.1 or higher.';
+
     /**
      * @var string
      */
@@ -466,7 +474,17 @@ class Cache implements StorageInterface
      */
     public function clear(): bool
     {
-        throw new NotImplementedException(__METHOD__ . '() not implemented yet');
+        try {
+            $this->call('kv.Clears', $this->request([]));
+        } catch (KeyValueException $e) {
+            if (\str_contains($e->getMessage(), 'can\'t find method kv.Clear')) {
+                throw new KeyValueException(self::ERROR_CLEAR_NOT_AVAILABLE, (int)$e->getCode(), $e);
+            }
+
+            throw $e;
+        }
+
+        return true;
     }
 
     /**

--- a/tests/CacheTestCase.php
+++ b/tests/CacheTestCase.php
@@ -369,13 +369,36 @@ class CacheTestCase extends TestCase
         $this->assertFalse($driver->has('__invalid_key__'));
     }
 
-    public function testClearNotAvailable(): void
+    public function testClear(): void
     {
-        $this->expectException(NotImplementedException::class);
-        $this->expectExceptionMessage(Cache::class . '::clear() not implemented yet');
+        $driver = $this->cache(['kv.Clear' => $this->response()]);
+
+        $result = $driver->clear();
+
+        $this->assertTrue($result);
+    }
+
+    public function testClearError(): void
+    {
+        $this->expectException(KeyValueException::class);
+        $this->expectExceptionMessage('Something went wrong');
+
+        $driver = $this->cache(['kv.Clear' => function () {
+            throw new ServiceException('Something went wrong');
+        }]);
+
+        $driver->clear();
+    }
+
+    public function testClearMethodNotFoundError(): void
+    {
+        $this->expectException(KeyValueException::class);
+        $this->expectExceptionMessage(
+            'RoadRunner does not support kv.Clear RPC method. ' .
+            'Please make sure you are using RoadRunner v2.3.1 or higher.'
+        );
 
         $driver = $this->cache();
-
         $driver->clear();
     }
 
@@ -568,7 +591,7 @@ class CacheTestCase extends TestCase
 
     public function testDelete(): void
     {
-        $driver = $this->cache();
+        $driver = $this->cache(['kv.Delete' => $this->response([])]);
         $this->assertTrue($driver->delete('key'));
     }
 
@@ -587,7 +610,7 @@ class CacheTestCase extends TestCase
 
     public function testDeleteMultiple(): void
     {
-        $driver = $this->cache();
+        $driver = $this->cache(['kv.Delete' => $this->response([])]);
         $this->assertTrue($driver->deleteMultiple(['key', 'key2']));
     }
 

--- a/tests/Stub/RPCConnectionStub.php
+++ b/tests/Stub/RPCConnectionStub.php
@@ -13,6 +13,8 @@ namespace Spiral\RoadRunner\KeyValue\Tests\Stub;
 
 use Spiral\Goridge\RPC\Codec\JsonCodec;
 use Spiral\Goridge\RPC\CodecInterface;
+use Spiral\Goridge\RPC\Exception\RPCException;
+use Spiral\Goridge\RPC\Exception\ServiceException;
 use Spiral\Goridge\RPC\RPCInterface;
 
 class RPCConnectionStub implements RPCInterface
@@ -53,7 +55,9 @@ class RPCConnectionStub implements RPCInterface
      */
     public function call(string $method, $payload, $options = null)
     {
-        $result = $this->mapping[$method] ?? '';
+        $result = $this->mapping[$method] ?? function () use ($method) {
+            throw new ServiceException('RPC: can\'t find method ' . $method);
+        };
 
         if ($result instanceof \Closure) {
             $result = $result($payload);


### PR DESCRIPTION
Added `clear` command support from RoadRunner v2.3.1: https://github.com/spiral/roadrunner/releases/tag/v2.3.1

Related docs: https://github.com/spiral/roadrunner-docs/pull/68