### PR TITLE
Mark Factory::isAvailable method as deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,6 @@ require __DIR__ . '/vendor/autoload.php';
 
 $factory = new Factory(RPC::create('tcp://127.0.0.1:6001'));
 
-if (!$factory->isAvailable()) {
-    throw new \LogicException('The [kv] plugin not available');
-}
-
 $cache = $factory->select('test');
 
 // After that you can write and read arbitrary values:

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -40,24 +40,11 @@ final class Factory implements FactoryInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @deprecated Information about RoadRunner plugins is not available since RoadRunner version 2.2
      */
     public function isAvailable(): bool
     {
-        try {
-            /** @var array<string>|mixed $result */
-            $result = $this->rpc
-                ->withCodec(new JsonCodec())
-                ->call('informer.List', true);
-
-            if (! \is_array($result)) {
-                return false;
-            }
-
-            return \in_array('kv', $result, true);
-        } catch (\Throwable $e) {
-            return false;
-        }
+        throw new \RuntimeException(\sprintf('%s::isAvailable method is deprecated.', self::class));
     }
 
     /**

--- a/src/FactoryInterface.php
+++ b/src/FactoryInterface.php
@@ -16,13 +16,6 @@ use Spiral\RoadRunner\KeyValue\Serializer\SerializerAwareInterface;
 interface FactoryInterface extends SerializerAwareInterface
 {
     /**
-     * Returns information about whether a key value plugin is available.
-     *
-     * @return bool
-     */
-    public function isAvailable(): bool;
-
-    /**
      * Create a shared cache storage by its name.
      *
      * @param string $name

--- a/tests/FactoryTestCase.php
+++ b/tests/FactoryTestCase.php
@@ -31,33 +31,6 @@ class FactoryTestCase extends TestCase
         $this->factory();
     }
 
-    public function testIsAvailable(): void
-    {
-        $factory = $this->factory(['informer.List' => '["kv"]']);
-        $this->assertTrue($factory->isAvailable());
-    }
-
-    public function testNotAvailable(): void
-    {
-        $factory = $this->factory(['informer.List' => '[]']);
-        $this->assertFalse($factory->isAvailable());
-    }
-
-    public function testNotAvailableOnNonArrayResponse(): void
-    {
-        $factory = $this->factory(['informer.List' => '42']);
-        $this->assertFalse($factory->isAvailable());
-    }
-
-    public function testNotAvailableOnErrorResponse(): void
-    {
-        $factory = $this->factory(['informer.List' => (static function () {
-            throw new \Exception();
-        })]);
-
-        $this->assertFalse($factory->isAvailable());
-    }
-
     public function testSuccessSelectOfUnknownStorage(): void
     {
         $name = \random_bytes(32);


### PR DESCRIPTION
Since RoadRunner version 2.3 there is not an ability to get list of available plugins via RPC and every time when developers started using this package they bumped into a problem with `Factory::isAvailable` method. With this PR the method was marked as a deprecated and now it will throw an exception with information about deprecation.