### PR TITLE
Fix documentation links

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,7 +1,6 @@
 on:
   push:
     branches:
-      - master
       - '*.*'
   pull_request: null
 
@@ -13,7 +12,5 @@ jobs:
     with:
       os: >-
         ['ubuntu-latest']
-      php: >-
-        ['8.1', '8.2']
       stability: >-
         ['prefer-stable']

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,7 +1,6 @@
 on:
   push:
     branches:
-      - master
       - '*.*'
   pull_request: null
 
@@ -13,5 +12,3 @@ jobs:
     with:
       os: >-
         ['ubuntu-latest']
-      php: >-
-        ['8.1']

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Codecov](https://codecov.io/gh/spiral/roadrunner-kv/branch/master/graph/badge.svg)](https://codecov.io/gh/spiral/roadrunner-kv/)
 [![Total Downloads](https://poser.pugx.org/spiral/roadrunner-kv/downloads)](https://packagist.org/packages/spiral/roadrunner-kv)
 
-<b>[Documentation](https://roadrunner.dev/docs/plugins-kv/2.x/en)</b> | [Framework Bundle](https://github.com/spiral/framework)
+<b>[Documentation](https://docs.roadrunner.dev/key-value/overview-kv)</b> | [Framework Bundle](https://github.com/spiral/framework)
 
 This repository contains the codebase PSR-16 PHP cache bridge using kv RoadRunner plugin.
 
@@ -45,7 +45,7 @@ kv:
 
 > **Note**
 > Read more about all available drivers on the 
-> [documentation](https://roadrunner.dev/docs) page.
+> [documentation](https://docs.roadrunner.dev) page.
 
 After starting the server with this configuration, one driver named "`test`" 
 will be available to you.

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "homepage": "https://roadrunner.dev/",
     "support": {
-        "docs": "https://roadrunner.dev/docs",
+        "docs": "https://docs.roadrunner.dev",
         "issues": "https://github.com/roadrunner-server/roadrunner/issues",
         "forum": "https://forum.roadrunner.dev/",
         "chat": "https://discord.gg/V6EK4he"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ❌ 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub workflows to remove `master` branch restriction and adjusted PHP version configuration.

- **Documentation**
	- Updated documentation links in the README to reflect new URLs for the PSR-16 PHP cache bridge using kv RoadRunner plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->