### PR TITLE
Add support for RoadRunner v2024.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "ext-json": "*",
         "psr/simple-cache": "3",
         "roadrunner-php/roadrunner-api-dto": "^1.0",
-        "spiral/roadrunner": "^2023.1",
+        "spiral/roadrunner": "^2023.1 || ^2024.1",
         "spiral/goridge": "^4.0",
         "google/protobuf": "^3.7"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ❌ 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version constraint for the "spiral/roadrunner" package to support both 2023.1 and 2024.1 versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->