### PR TITLE
Add psr/simple-cache v2

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -13,4 +13,4 @@ jobs:
       os: >-
         ['ubuntu-latest']
       stability: >-
-        ['prefer-stable']
+        ['prefer-lowest', 'prefer-stable']

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -12,3 +12,5 @@ jobs:
     with:
       os: >-
         ['ubuntu-latest']
+      php: >-
+        ['8.1']

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     "require": {
         "php": ">=8.1",
         "ext-json": "*",
-        "psr/simple-cache": "3",
+        "psr/simple-cache": "2 - 3",
         "roadrunner-php/roadrunner-api-dto": "^1.0",
         "spiral/roadrunner": "^2023.1 || ^2024.1",
         "spiral/goridge": "^4.0",


### PR DESCRIPTION
Just allows psr/simple-cache v2 because it's compatible with the existing implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the compatibility for the "psr/simple-cache" library to support versions 2 and 3, enhancing flexibility in dependency management.
- **Chores**
	- Modified the stability preference in PHPUnit workflows to include both 'prefer-lowest' and 'prefer-stable', providing more control over package versions.
- **Chores**
	- Added PHP version 8.1 to the list of operating systems in the GitHub Actions workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->