### PR TITLE
Removing google/protobuf dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,8 +49,7 @@
         "psr/simple-cache": "2 - 3",
         "roadrunner-php/roadrunner-api-dto": "^1.0",
         "spiral/goridge": "^4.2",
-        "spiral/roadrunner": "^2023.1 || ^2024.1",
-        "google/protobuf": "^3.7"
+        "spiral/roadrunner": "^2023.1 || ^2024.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌
| Issues        | #https://github.com/roadrunner-php/issues/issues/35

The `google/protobuf` dependency has been removed because it is not used anywhere in the package.